### PR TITLE
Add signature

### DIFF
--- a/index.md
+++ b/index.md
@@ -116,6 +116,7 @@ Feel free to list an affiliation with an institution, organization, or company, 
 - **Alix Bird** (Ph.D. Candidate, Australian Institute of Machine Learning, The University of Adelaide)
 - **Bronwyn Bjorkman** (Queen's University)
 - **Griffin Boyce** (Google)
+- **Christian Brickhouse** (Stanford University)
 - **Ozan Caglayan** (Imperial College London)
 - **Alfredo Carpineti** (Pride in STEM)
 - **Tiffany Chan** (University of Victoria Libraries)


### PR DESCRIPTION
Google scholar fails to meet the ethical standards of the research publication industry with regards to name changes. This alone would be enough to stop using the platform, but in my use the search results and bibliographic information provided are often inaccurate and unreliable which only compounds the issue of unethical naming practices for trans scholars. Given their failures as a platform, I will not use Google Scholar until they meet the demands listed in this document.